### PR TITLE
Patch isMatch iteration implementation and test cases

### DIFF
--- a/7-hours/isMatch.spec.ts
+++ b/7-hours/isMatch.spec.ts
@@ -2,14 +2,20 @@ import isMatch, { recuration, iteration } from './isMatch';
 
 describe('基本案例', (): void => {
   test.each`
-    text        | pattern     | expected
-    ${''}       | ${''}       | ${true}
-    ${'a'}      | ${''}       | ${false}
-    ${''}       | ${'a'}      | ${false}
-    ${'abc'}    | ${'abc'}    | ${true}
-    ${'abcabc'} | ${'a.c..c'} | ${true}
-    ${'aabbcc'} | ${'a*'}     | ${true}
-  `('$"text" <-> "$pattern"', ({ text, pattern, expected }): void => {
+    text            | pattern          | expected
+    ${''}           | ${''}            | ${true}
+    ${'a'}          | ${''}            | ${false}
+    ${''}           | ${'a'}           | ${false}
+    ${'abcabbaabc'} | ${'abcabbaabc'}  | ${true}
+    ${'abcabbaabc'} | ${'ab......bc'}  | ${true}
+    ${'abcabbaabc'} | ${'ab.......bc'} | ${false}
+    ${'abcabbaabc'} | ${'ab.*.bc'}     | ${true}
+    ${'abcabbaabc'} | ${'ab*ab*ab*'}   | ${true}
+    ${'abcabbaabc'} | ${'a*'}          | ${true}
+    ${'abcabbaabc'} | ${'a*c'}         | ${true}
+    ${'abcabbaabc'} | ${'*c'}          | ${true}
+    ${'abcabbaabc'} | ${'*'}           | ${true}
+  `('$"$text" <-> "$pattern"', ({ text, pattern, expected }): void => {
     expect(recuration(text, pattern)).toBe(expected);
     expect(iteration(text, pattern)).toBe(expected);
   });
@@ -20,6 +26,7 @@ describe('高複雜度案例', (): void => {
     text            | pattern                  | expected
     ${'abcbcbcbcd'} | ${'a**bc*bc*'}           | ${true}
     ${'abcbcbcbcd'} | ${'********..*****..*k'} | ${false}
+    ${'abcabbaabc'} | ${'ab*ab*ab*ab*'}        | ${false}
   `('"$text" <-> "$pattern"', ({ text, pattern, expected }): void => {
     expect(isMatch(text, pattern)).toBe(expected);
   });

--- a/7-hours/isMatch.ts
+++ b/7-hours/isMatch.ts
@@ -33,24 +33,31 @@ export function iteration(text: string, pattern: string): boolean {
   let indexP = 0;
   let tester = '';
 
-  while (indexP < pattern.length) {
+  while (indexP < pattern.length || anchorT < text.length) {
     const char = text[indexT];
     tester = pattern[indexP];
 
+    // 如果判斷子為 * 重設 anchor
     if (tester === '*') {
       anchorT = indexT;
-      anchorP = indexP;
-      indexP += 1;
+      anchorP = ++indexP;
       continue;
     }
 
+    // 剛好 text & pattern 都測試到終點，通過測試
+    if (tester === undefined && char === undefined) {
+      return true;
+    }
+
+    // 單字節符合規則，繼續前進
     if (tester === '.' || tester === char) {
       indexP += 1;
       indexT += 1;
       continue;
     }
 
-    if (anchorT < indexT) {
+    // 不合規則，判斷 index 是否可以往回至 anchor
+    if (anchorT < text.length) {
       indexT = ++anchorT;
       indexP = anchorP;
       continue;
@@ -58,7 +65,6 @@ export function iteration(text: string, pattern: string): boolean {
 
     return false;
   }
-
   return tester === '*' || indexT === text.length;
 }
 


### PR DESCRIPTION
之前 isMatch 重寫有漏掉的部分，修正

### 驗證

可以直接透過 Deno REPL 測試

```ts
let isMatch;
(async () => { const m = await import('./7-ours/isMatch.ts'); isMatch = m.default })();
isMatch('abcabbaabc', 'a*c');
// true
```
